### PR TITLE
Safe btnMenu

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -28,7 +28,7 @@
 
       // mobile menu
       const btnMenu = document.querySelector(".btn-menu");
-      btnMenu.addEventListener("click", () => {
+      btnMenu?.addEventListener("click", () => {
         htmlClass.toggle("open");
       });
 


### PR DESCRIPTION
The bntMenu element is conditionally rendered depending on the extra menus

Without extra menus I was getting this error
```
Uncaught TypeError: btnMenu is null
    <anonymous> http://127.0.0.1:1111/:88
127.0.0.1:1111:88:7
```
and it was also not enabling other JS code to work, such as the dark-light theme switch

For safety with all configurations, we can check if it's null with this PR